### PR TITLE
REP-132 Add rd_language parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,5 +38,6 @@ The following options are available:
  part, and does not have a trailing slash.
 * **rd_region** default `London` Either `London` or `Wales`.  This controls which default view of the map is shown and 
 which businesses are included.
+* **rd_language** default `en` Either `en` (British English) or `cy` (Welsh). This controls which language is shown.
 * **width** default `100%` Size of the map shown.
 * **height** default `600` Height of the map shown.

--- a/repair-directory.php
+++ b/repair-directory.php
@@ -45,7 +45,7 @@ function repair_directory_plugin_add_shortcode_cb($atts)
     // variables the Repair Directory will use, and we don't want to introduce that dependency.
     $params = [
         'rd_region' => esc_attr($atts['rd_region']),
-        'rd_lanauge' => esc_attr($atts['rd_language']),
+        'rd_language' => esc_attr($atts['rd_language']),
         'rd_parenturl' => esc_attr($atts['rd_parenturl'])
     ];
 

--- a/repair-directory.php
+++ b/repair-directory.php
@@ -51,7 +51,7 @@ function repair_directory_plugin_add_shortcode_cb($atts)
 
     unset($atts['rd_region']);
     unset($atts['rd_parenturl']);
-    unset($atts['rd_style']);
+    unset($atts['rd_language']);
 
     foreach ($_GET as $var => $value) {
         if (strpos($var, 'rd_') === 0) {

--- a/repair-directory.php
+++ b/repair-directory.php
@@ -23,6 +23,7 @@ function repair_directory_plugin_add_shortcode_cb($atts)
         'src' => 'https://map.restarters.net/',
         'rd_parenturl' => 'https://map.restarters.net',
         'rd_region' => 'London',
+        'rd_language' => 'en',
         'width' => '100%',
         'height' => '600',
         'scrolling' => 'no',
@@ -44,6 +45,7 @@ function repair_directory_plugin_add_shortcode_cb($atts)
     // variables the Repair Directory will use, and we don't want to introduce that dependency.
     $params = [
         'rd_region' => esc_attr($atts['rd_region']),
+        'rd_lanauge' => esc_attr($atts['rd_language']),
         'rd_parenturl' => esc_attr($atts['rd_parenturl'])
     ];
 

--- a/repair-directory.php
+++ b/repair-directory.php
@@ -51,6 +51,7 @@ function repair_directory_plugin_add_shortcode_cb($atts)
 
     unset($atts['rd_region']);
     unset($atts['rd_parenturl']);
+    unset($atts['rd_style']);
 
     foreach ($_GET as $var => $value) {
         if (strpos($var, 'rd_') === 0) {


### PR DESCRIPTION
This adds the `rd_language` parameter so that you can select which language is used.    Currently just English and Welsh.